### PR TITLE
App store country codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@
 ## 0.3.2
 
 - Fix for IOS 
+
+## 0.4.0
+
+- Add country codes for App Store look-up

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ dependencies:
 ...
 ```
 
+#### Or
+If your app is not published in the US App Store, you can provide a list of countries where it's available:
+```dart
+  final _checker = AppVersionChecker(
+      appStoreCountryCodes: ["DE", "US", "IT"]);
+...
+```
+
 #### Use on ApkPure Store
 
 ```dart
@@ -51,4 +59,3 @@ dependencies:
   );
 ...
 ```
-

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_app_version_checker
 description: A lightweight flutter plugin to check if your app is up-to-date on Google Play Store or Apple App Store
-version: 0.3.2
+version: 0.4.0
 homepage: https://github.com/X-SLAYER/app_version_checker
 documentation: https://github.com/X-SLAYER/app_version_checker
 


### PR DESCRIPTION
The current code uses the `itunes.apple.com/lookup?bundleId=<app id>` URL to fetch app data, without a `country=<iso code>` param, that API defaults to looking up in the US store only.

If the app is not published in the US store, then, we get 0 results whereas there would be a result if we use the appropriate country.

This adds support to receive a list of country codes to search with